### PR TITLE
Updated Movie Autoexec to use player crosshairs

### DIFF
--- a/microservices/recorder/cfg/recorder.cfg
+++ b/microservices/recorder/cfg/recorder.cfg
@@ -61,6 +61,7 @@ cl_crosshairthickness 2
 cl_crosshairusealpha 1
 cl_crosshair_drawoutline 0
 cl_crosshair_sniper_width 2
+cl_show_observer_crosshair 2
 
 sv_skyname vertigoblue_hdr
 mat_postprocess_enable 0


### PR DESCRIPTION
Added `cl_show_observer_crosshair 2`, which should allow the demo/recording to use the players crosshair instead of the current white crosshair